### PR TITLE
feat(components): add shared TSBC components with tests

### DIFF
--- a/src/app/shared/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/accordion/accordion.component.scss
@@ -1,0 +1,68 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-accordion {
+  border: 1px solid $primary-mid;
+  border-radius: $border-radius-sm;
+  overflow: hidden;
+
+  & + & {
+    margin-top: $space-xs;
+  }
+}
+
+.accordion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: $space-sm $space-md;
+  background: $white;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background $transition;
+
+  &:hover {
+    background: $primary-light;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $secondary;
+    outline-offset: -2px;
+  }
+}
+
+.accordion-title {
+  font-size: $font-size-body;
+  font-weight: $font-weight-semibold;
+  color: $primary-dark;
+  margin: 0;
+}
+
+.accordion-icon {
+  font-size: $font-size-small;
+  color: $primary;
+  transition: transform $transition;
+  flex-shrink: 0;
+  margin-left: $space-sm;
+
+  &.open {
+    transform: rotate(180deg);
+  }
+}
+
+.accordion-panel {
+  border-top: 1px solid $primary-mid;
+}
+
+.accordion-content {
+  padding: $space-md;
+  font-size: $font-size-body;
+  line-height: $line-height;
+  color: $text-dark;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $space-sm;
+    font-size: $font-size-body-min;
+  }
+}

--- a/src/app/shared/components/accordion/accordion.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AccordionComponent } from './accordion.component';
+
+describe('AccordionComponent', () => {
+  let component: AccordionComponent;
+  let fixture: ComponentFixture<AccordionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AccordionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AccordionComponent);
+    component = fixture.componentInstance;
+    component.title = 'When Do I Need to Renew?';
+    component.panelId = 'renew';
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should start closed', () => {
+    expect(component.isOpen).toBeFalse();
+  });
+
+  it('should toggle open and closed', () => {
+    component.toggle();
+    expect(component.isOpen).toBeTrue();
+    component.toggle();
+    expect(component.isOpen).toBeFalse();
+  });
+
+  it('should render title', () => {
+    fixture.detectChanges();
+    const title = fixture.nativeElement.querySelector('.accordion-title');
+    expect(title.textContent).toContain('When Do I Need to Renew?');
+  });
+
+  it('should have aria-expanded attribute', () => {
+    fixture.detectChanges();
+    const header = fixture.nativeElement.querySelector('.accordion-header');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    component.toggle();
+    fixture.detectChanges();
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('should show panel content when open', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.accordion-panel')).toBeNull();
+    component.toggle();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.accordion-panel')).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-accordion',
+  standalone: true,
+  template: `
+    <div class="tsbc-accordion">
+      <button
+        class="accordion-header"
+        (click)="toggle()"
+        [attr.aria-expanded]="isOpen"
+        [attr.aria-controls]="'accordion-' + panelId"
+      >
+        <h3 class="accordion-title">{{ title }}</h3>
+        <span class="accordion-icon" [class.open]="isOpen" aria-hidden="true">&#9660;</span>
+      </button>
+      @if (isOpen) {
+        <div
+          class="accordion-panel"
+          [id]="'accordion-' + panelId"
+          role="region"
+        >
+          <div class="accordion-content">
+            <ng-content />
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styleUrl: './accordion.component.scss',
+})
+export class AccordionComponent {
+  @Input() title = '';
+  @Input() panelId = '';
+  isOpen = false;
+
+  toggle(): void {
+    this.isOpen = !this.isOpen;
+  }
+}

--- a/src/app/shared/components/card/card.component.scss
+++ b/src/app/shared/components/card/card.component.scss
@@ -1,0 +1,87 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-card {
+  display: flex;
+  flex-direction: column;
+  background: $white;
+  border-radius: $border-radius;
+  box-shadow: $card-shadow;
+  border: 2px solid transparent;
+  padding: $space-lg;
+  transition: all $transition;
+  cursor: pointer;
+  text-decoration: none;
+  color: $text-dark;
+
+  &:hover {
+    background: $primary-dark;
+    color: $white;
+    border-color: $primary-dark;
+
+    .card-tag {
+      color: $primary-mid;
+    }
+
+    .card-cta {
+      color: $white;
+    }
+  }
+
+  &.dark {
+    background: $primary;
+    color: $white;
+
+    .card-tag {
+      color: $primary-mid;
+    }
+
+    .card-cta {
+      color: $white;
+    }
+
+    &:hover {
+      background: $primary-dark;
+    }
+  }
+}
+
+.card-tag {
+  font-size: $font-size-tag;
+  font-weight: $font-weight-bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: $gray;
+  margin-bottom: $space-sm;
+}
+
+.card-title {
+  font-size: $font-size-body;
+  font-weight: $font-weight-bold;
+  margin-bottom: $space-sm;
+  line-height: 1.3;
+}
+
+.card-description {
+  font-size: $font-size-small;
+  line-height: 1.5;
+  margin-bottom: $space-md;
+  flex: 1;
+}
+
+.card-cta {
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+  color: $primary;
+  display: flex;
+  align-items: center;
+  gap: $space-xs;
+  margin-top: auto;
+}
+
+.cta-arrow {
+  transition: transform $transition;
+
+  .tsbc-card:hover & {
+    transform: translateX(4px);
+  }
+}

--- a/src/app/shared/components/card/card.component.spec.ts
+++ b/src/app/shared/components/card/card.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render title', () => {
+    component.title = 'Robotics Certification';
+    fixture.detectChanges();
+    const title = fixture.nativeElement.querySelector('.card-title');
+    expect(title.textContent).toContain('Robotics Certification');
+  });
+
+  it('should render tag when provided', () => {
+    component.tag = 'New';
+    component.title = 'Test';
+    fixture.detectChanges();
+    const tag = fixture.nativeElement.querySelector('.card-tag');
+    expect(tag).toBeTruthy();
+    expect(tag.textContent).toContain('New');
+  });
+
+  it('should not render tag when empty', () => {
+    component.title = 'Test';
+    fixture.detectChanges();
+    const tag = fixture.nativeElement.querySelector('.card-tag');
+    expect(tag).toBeNull();
+  });
+
+  it('should apply dark class when dark is true', () => {
+    component.title = 'Test';
+    component.dark = true;
+    fixture.detectChanges();
+    const card = fixture.nativeElement.querySelector('.tsbc-card');
+    expect(card.classList).toContain('dark');
+  });
+
+  it('should render CTA text when provided', () => {
+    component.title = 'Test';
+    component.ctaText = 'Learn More';
+    fixture.detectChanges();
+    const cta = fixture.nativeElement.querySelector('.card-cta');
+    expect(cta.textContent).toContain('Learn More');
+  });
+});

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-card',
+  standalone: true,
+  template: `
+    <a [href]="link" class="tsbc-card" [class.dark]="dark" role="article">
+      @if (tag) {
+        <span class="card-tag">{{ tag }}</span>
+      }
+      <h3 class="card-title">{{ title }}</h3>
+      @if (description) {
+        <p class="card-description">{{ description }}</p>
+      }
+      @if (ctaText) {
+        <span class="card-cta">
+          {{ ctaText }}
+          <span class="cta-arrow" aria-hidden="true">&rarr;</span>
+        </span>
+      }
+    </a>
+  `,
+  styleUrl: './card.component.scss',
+})
+export class CardComponent {
+  @Input() tag = '';
+  @Input() title = '';
+  @Input() description = '';
+  @Input() link = '#';
+  @Input() ctaText = '';
+  @Input() dark = false;
+}

--- a/src/app/shared/components/cta-banner/cta-banner.component.scss
+++ b/src/app/shared/components/cta-banner/cta-banner.component.scss
@@ -1,0 +1,58 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-cta-banner {
+  padding: $space-xl $padding-desktop;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $space-lg $padding-mobile;
+  }
+}
+
+.cta-container {
+  max-width: $max-width;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $space-lg;
+
+  @media (max-width: $breakpoint-mobile) {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+.cta-content {
+  flex: 1;
+}
+
+.cta-heading {
+  color: $white;
+  font-size: $font-size-h3;
+  margin-bottom: $space-sm;
+}
+
+.cta-body {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: $font-size-body-min;
+  line-height: 1.6;
+}
+
+.cta-button {
+  display: inline-block;
+  background: $white;
+  color: $primary;
+  padding: $space-sm $space-lg;
+  border-radius: $border-radius-sm;
+  font-size: $font-size-small;
+  font-weight: $font-weight-bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  transition: all $transition;
+
+  &:hover {
+    background: $primary-light;
+    color: $primary-dark;
+  }
+}

--- a/src/app/shared/components/cta-banner/cta-banner.component.spec.ts
+++ b/src/app/shared/components/cta-banner/cta-banner.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { CtaBannerComponent } from './cta-banner.component';
+
+describe('CtaBannerComponent', () => {
+  let component: CtaBannerComponent;
+  let fixture: ComponentFixture<CtaBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CtaBannerComponent, RouterModule.forRoot([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CtaBannerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render heading', () => {
+    component.heading = 'Renew Your Certificate';
+    fixture.detectChanges();
+    const heading = fixture.nativeElement.querySelector('.cta-heading');
+    expect(heading.textContent).toContain('Renew Your Certificate');
+  });
+
+  it('should render body when provided', () => {
+    component.heading = 'Test';
+    component.body = 'Renew before deadline';
+    fixture.detectChanges();
+    const body = fixture.nativeElement.querySelector('.cta-body');
+    expect(body).toBeTruthy();
+    expect(body.textContent).toContain('Renew before deadline');
+  });
+
+  it('should render button when buttonText provided', () => {
+    component.heading = 'Test';
+    component.buttonText = 'Renew Now';
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('.cta-button');
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toContain('Renew Now');
+  });
+
+  it('should apply default background color', () => {
+    expect(component.backgroundColor).toBe('#00497B');
+  });
+});

--- a/src/app/shared/components/cta-banner/cta-banner.component.ts
+++ b/src/app/shared/components/cta-banner/cta-banner.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-cta-banner',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <section class="tsbc-cta-banner" [style.background-color]="backgroundColor">
+      <div class="cta-container">
+        <div class="cta-content">
+          <h2 class="cta-heading">{{ heading }}</h2>
+          @if (body) {
+            <p class="cta-body">{{ body }}</p>
+          }
+        </div>
+        @if (buttonText) {
+          <a [routerLink]="buttonLink" class="cta-button">{{ buttonText }}</a>
+        }
+      </div>
+    </section>
+  `,
+  styleUrl: './cta-banner.component.scss',
+})
+export class CtaBannerComponent {
+  @Input() heading = '';
+  @Input() body = '';
+  @Input() buttonText = '';
+  @Input() buttonLink = '#';
+  @Input() backgroundColor = '#00497B';
+}

--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -1,0 +1,147 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-footer {
+  margin-top: $space-2xl;
+}
+
+.back-to-top {
+  background: $primary;
+  padding: $space-xl $padding-desktop;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $space-lg $padding-mobile;
+  }
+}
+
+.back-to-top-container {
+  max-width: $max-width;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: $space-md;
+}
+
+.back-to-top-btn {
+  background: none;
+  border: none;
+  color: $white;
+  font-family: $font-family;
+  font-size: $font-size-body;
+  font-weight: $font-weight-semibold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: $space-xs;
+  transition: opacity $transition;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.arrow-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: $primary-mid;
+  border-radius: $border-radius-sm;
+  font-size: 18px;
+  color: $primary-dark;
+}
+
+.footer-actions {
+  display: flex;
+  gap: $space-sm;
+
+  @media (max-width: $breakpoint-mobile) {
+    flex-direction: column;
+    width: 100%;
+  }
+}
+
+.footer-btn {
+  display: inline-block;
+  padding: $space-sm $space-md;
+  border-radius: $border-radius-sm;
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: all $transition;
+
+  &.primary {
+    background: $white;
+    color: $primary;
+
+    &:hover {
+      background: $primary-light;
+    }
+  }
+
+  &.secondary {
+    background: transparent;
+    color: $white;
+    border: 2px solid $white;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+}
+
+.footer-content {
+  background: $primary-dark;
+  padding: $space-xl $padding-desktop;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $space-lg $padding-mobile;
+  }
+}
+
+.footer-container {
+  max-width: $max-width;
+  margin: 0 auto;
+}
+
+.acknowledgment,
+.privacy {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: $font-size-small;
+  line-height: 1.6;
+  margin-bottom: $space-md;
+}
+
+.footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: $space-md;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  flex-wrap: wrap;
+  gap: $space-sm;
+}
+
+.copyright {
+  color: $white;
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+}
+
+.footer-links {
+  display: flex;
+  gap: $space-md;
+
+  a {
+    color: rgba(255, 255, 255, 0.7);
+    font-size: $font-size-small;
+    transition: color $transition;
+
+    &:hover {
+      color: $white;
+    }
+  }
+}

--- a/src/app/shared/components/footer/footer.component.spec.ts
+++ b/src/app/shared/components/footer/footer.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FooterComponent } from './footer.component';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display current year', () => {
+    expect(component.currentYear).toBe(new Date().getFullYear());
+  });
+
+  it('should render copyright text', () => {
+    const copyright = fixture.nativeElement.querySelector('.copyright');
+    expect(copyright.textContent).toContain('Technical Safety BC');
+  });
+
+  it('should have back to top button', () => {
+    const btn = fixture.nativeElement.querySelector('.back-to-top-btn');
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute('aria-label')).toBe('Back to top');
+  });
+
+  it('should call scrollToTop on button click', () => {
+    spyOn(window, 'scrollTo');
+    component.scrollToTop();
+    expect(window.scrollTo).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  template: `
+    <footer class="tsbc-footer">
+      <div class="back-to-top">
+        <div class="back-to-top-container">
+          <button class="back-to-top-btn" (click)="scrollToTop()" aria-label="Back to top">
+            <span class="arrow-icon">&#8593;</span>
+            <span>Back To Top</span>
+          </button>
+          <div class="footer-actions">
+            <a href="#" class="footer-btn primary">Report An Incident</a>
+            <a href="#" class="footer-btn secondary">Contact Us</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-content">
+        <div class="footer-container">
+          <p class="acknowledgment">
+            Technical Safety BC acknowledges our work takes place on the traditional territories
+            of Indigenous Peoples across British Columbia.
+          </p>
+          <p class="privacy">
+            The personal information on this form is collected under the authority of the
+            Safety Standards Act. If you have questions about the collection of your personal
+            information, please contact the Manager, Legislative Services.
+          </p>
+          <div class="footer-bottom">
+            <p class="copyright">&copy; {{ currentYear }} Technical Safety BC</p>
+            <div class="footer-links">
+              <a href="#">Cookie Policy</a>
+              <a href="#">Privacy Policy</a>
+              <a href="#">Terms of Use</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  `,
+  styleUrl: './footer.component.scss',
+})
+export class FooterComponent {
+  currentYear = new Date().getFullYear();
+
+  scrollToTop(): void {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+}

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,0 +1,116 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-header {
+  background: $white;
+  border-bottom: 2px solid $primary-light;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-container {
+  max-width: $max-width;
+  margin: 0 auto;
+  padding: 0 $padding-desktop;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 80px;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 0 $padding-mobile;
+    height: 64px;
+  }
+}
+
+.logo-link {
+  display: flex;
+  align-items: center;
+}
+
+.logo {
+  height: 40px;
+  width: auto;
+
+  @media (max-width: $breakpoint-mobile) {
+    height: 32px;
+  }
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: $space-lg;
+
+  @media (max-width: $breakpoint-mobile) {
+    display: none;
+  }
+}
+
+.nav-link {
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+  color: $text-dark;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: $space-xs $space-sm;
+  transition: color $transition;
+
+  &:hover {
+    color: $secondary;
+  }
+}
+
+.login-btn {
+  background: $primary;
+  color: $white;
+  border-radius: $border-radius-sm;
+  padding: $space-xs $space-md;
+
+  &:hover {
+    background: $primary-dark;
+    color: $white;
+  }
+}
+
+.mobile-menu-btn {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: $space-xs;
+
+  @media (max-width: $breakpoint-mobile) {
+    display: flex;
+  }
+}
+
+.hamburger-line {
+  display: block;
+  width: 24px;
+  height: 3px;
+  background: $text-dark;
+  border-radius: 2px;
+}
+
+.mobile-nav {
+  display: flex;
+  flex-direction: column;
+  background: $white;
+  border-top: 1px solid $primary-light;
+  padding: $space-sm $padding-mobile;
+}
+
+.mobile-nav-link {
+  padding: $space-sm 0;
+  font-size: $font-size-body-min;
+  font-weight: $font-weight-semibold;
+  color: $text-dark;
+  border-bottom: 1px solid $primary-light;
+
+  &:hover {
+    color: $secondary;
+  }
+}

--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeaderComponent, RouterModule.forRoot([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should start with menu closed', () => {
+    expect(component.menuOpen).toBeFalse();
+  });
+
+  it('should toggle menu on toggleMenu()', () => {
+    component.toggleMenu();
+    expect(component.menuOpen).toBeTrue();
+    component.toggleMenu();
+    expect(component.menuOpen).toBeFalse();
+  });
+
+  it('should render TSBC logo', () => {
+    const logo = fixture.nativeElement.querySelector('.logo');
+    expect(logo).toBeTruthy();
+    expect(logo.alt).toContain('Technical Safety BC');
+  });
+
+  it('should have accessible mobile menu button', () => {
+    const btn = fixture.nativeElement.querySelector('.mobile-menu-btn');
+    expect(btn.getAttribute('aria-label')).toBe('Toggle navigation menu');
+  });
+});

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <header class="tsbc-header">
+      <div class="header-container">
+        <a routerLink="/robotics" class="logo-link" aria-label="Technical Safety BC - Home">
+          <img src="/assets/logos/tsbc-logo-rgb.jpg" alt="Technical Safety BC" class="logo" />
+        </a>
+        <nav class="nav-links" aria-label="Main navigation">
+          <a routerLink="/robotics" class="nav-link">Technologies</a>
+          <a routerLink="/robotics" class="nav-link">Safety in BC</a>
+          <a href="#" class="nav-link login-btn">Login</a>
+        </nav>
+        <button
+          class="mobile-menu-btn"
+          (click)="toggleMenu()"
+          [attr.aria-expanded]="menuOpen"
+          aria-label="Toggle navigation menu"
+        >
+          <span class="hamburger-line"></span>
+          <span class="hamburger-line"></span>
+          <span class="hamburger-line"></span>
+        </button>
+      </div>
+      @if (menuOpen) {
+        <nav class="mobile-nav" aria-label="Mobile navigation">
+          <a routerLink="/robotics" class="mobile-nav-link" (click)="toggleMenu()">Technologies</a>
+          <a routerLink="/robotics" class="mobile-nav-link" (click)="toggleMenu()">Safety in BC</a>
+          <a href="#" class="mobile-nav-link" (click)="toggleMenu()">Login</a>
+        </nav>
+      }
+    </header>
+  `,
+  styleUrl: './header.component.scss',
+})
+export class HeaderComponent {
+  menuOpen = false;
+
+  toggleMenu(): void {
+    this.menuOpen = !this.menuOpen;
+  }
+}

--- a/src/app/shared/components/hero/hero.component.scss
+++ b/src/app/shared/components/hero/hero.component.scss
@@ -1,0 +1,58 @@
+@use '../../../../styles/variables' as *;
+
+.tsbc-hero {
+  padding: $space-3xl $padding-desktop;
+  overflow: hidden;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $space-xl $padding-mobile;
+  }
+}
+
+.hero-container {
+  max-width: $max-width;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $space-xl;
+
+  @media (max-width: $breakpoint-mobile) {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+.hero-content {
+  flex: 1;
+}
+
+.hero-title {
+  color: $text-dark;
+  margin-bottom: $space-md;
+}
+
+.hero-subtitle {
+  color: $text-dark;
+  font-size: $font-size-body;
+  line-height: 1.6;
+  max-width: 600px;
+
+  @media (max-width: $breakpoint-mobile) {
+    max-width: 100%;
+  }
+}
+
+.hero-image {
+  flex-shrink: 0;
+
+  img {
+    max-width: 400px;
+    height: auto;
+    border-radius: $border-radius;
+
+    @media (max-width: $breakpoint-mobile) {
+      max-width: 250px;
+    }
+  }
+}

--- a/src/app/shared/components/hero/hero.component.spec.ts
+++ b/src/app/shared/components/hero/hero.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HeroComponent } from './hero.component';
+
+describe('HeroComponent', () => {
+  let component: HeroComponent;
+  let fixture: ComponentFixture<HeroComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeroComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeroComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render title', () => {
+    component.title = 'Robotics';
+    fixture.detectChanges();
+    const title = fixture.nativeElement.querySelector('.hero-title');
+    expect(title.textContent).toContain('Robotics');
+  });
+
+  it('should render subtitle when provided', () => {
+    component.title = 'Robotics';
+    component.subtitle = 'Safety for all';
+    fixture.detectChanges();
+    const subtitle = fixture.nativeElement.querySelector('.hero-subtitle');
+    expect(subtitle).toBeTruthy();
+    expect(subtitle.textContent).toContain('Safety for all');
+  });
+
+  it('should not render subtitle when empty', () => {
+    component.title = 'Robotics';
+    component.subtitle = '';
+    fixture.detectChanges();
+    const subtitle = fixture.nativeElement.querySelector('.hero-subtitle');
+    expect(subtitle).toBeNull();
+  });
+
+  it('should apply default background color', () => {
+    expect(component.backgroundColor).toBe('#B5CEDF');
+  });
+
+  it('should render image when imageUrl provided', () => {
+    component.title = 'Test';
+    component.imageUrl = '/assets/test.png';
+    component.imageAlt = 'Test image';
+    fixture.detectChanges();
+    const img = fixture.nativeElement.querySelector('.hero-image img');
+    expect(img).toBeTruthy();
+    expect(img.alt).toBe('Test image');
+  });
+});

--- a/src/app/shared/components/hero/hero.component.ts
+++ b/src/app/shared/components/hero/hero.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-hero',
+  standalone: true,
+  template: `
+    <section class="tsbc-hero" [style.background-color]="backgroundColor">
+      <div class="hero-container">
+        <div class="hero-content">
+          <h1 class="hero-title">{{ title }}</h1>
+          @if (subtitle) {
+            <p class="hero-subtitle">{{ subtitle }}</p>
+          }
+        </div>
+        @if (imageUrl) {
+          <div class="hero-image">
+            <img [src]="imageUrl" [alt]="imageAlt" />
+          </div>
+        }
+      </div>
+    </section>
+  `,
+  styleUrl: './hero.component.scss',
+})
+export class HeroComponent {
+  @Input() title = '';
+  @Input() subtitle = '';
+  @Input() backgroundColor = '#B5CEDF';
+  @Input() imageUrl = '';
+  @Input() imageAlt = '';
+}


### PR DESCRIPTION
## Summary
- Add 6 reusable TSBC design system components: Header, Footer, Hero, Card, CTA Banner, Accordion
- All components use TSBC design tokens ($primary, $primary-dark, $primary-mid, etc.)
- WCAG AA accessible (aria-expanded, aria-controls, aria-label, role attributes)
- Responsive with mobile breakpoints
- 33 unit tests — all passing

## Components
| Component | Features |
|-----------|----------|
| Header | Sticky nav, TSBC logo, mobile hamburger, RouterLink |
| Footer | Back-to-top scroll, Indigenous acknowledgment, copyright |
| Hero | Configurable title/subtitle/image/backgroundColor |
| Card | Tag, title, description, CTA arrow, dark variant |
| CTA Banner | Full-width banner with heading, body, RouterLink button |
| Accordion | Toggle open/close, aria-expanded, ng-content body |

## Test plan
- [x] `ng build` — passes
- [x] `ng lint` — passes
- [x] `ng test` — 33/33 specs passing

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)